### PR TITLE
Update class-methods.rst

### DIFF
--- a/docs/topics/class-methods.rst
+++ b/docs/topics/class-methods.rst
@@ -1,5 +1,5 @@
 ===========================
-Class Instantiation Methods
+Class Factory Methods
 ===========================
 
 These methods create an instance of their implementer class by 
@@ -21,8 +21,7 @@ extracting the components needed for it from the argument that the method takes.
 
     This class method is used by Scrapy to create an instance of the implementer class
     using the settings passed as arguments.
-    In most implementations of this method, not all settings given will be used 
-    to instantiate the class, but only the ones needed in the specific scenario.
+    This class method will not be called at all if from_crawler is defined.
 
 
     :param settings: project settings


### PR DESCRIPTION
1. We need to be consistent with vocabulary. We should call them either ‘instantiation methods’ or ‘factory methods’, but we should stick to 1 name. I am slightly in favor of the later, but I have no strong opinion on it. (resolved)

2. I don’t think this bit is needed. It is up to the user which settings they want to use, and using a lot or 1 should make no difference.

On the other hand, in this definition I miss the fact that this class method will not be called at all if from_crawler is also defined, which I believe it a rather important detail. (resolved) 